### PR TITLE
 #11: Fix Ordered

### DIFF
--- a/bop/postwait.c
+++ b/bop/postwait.c
@@ -105,6 +105,7 @@ void channel_fill( addr_t id, addr_t base, unsigned size ) {
   if ( local_ch_id == 0 ) local_ch_id = id;
 
   map_add_range( & local_ch_data, base, size, NULL );
+  bop_msg( 4, "channel fill : map_add_range %p, %p, %.0f, %d", &local_ch_data, base, *((double *)base), size);
 }
 
 extern map_t read_map;
@@ -151,6 +152,8 @@ void channel_post( addr_t id ) {
     }
   }
   bop_lock_release( & switch_board.lock );
+
+  map_subtract( & write_map, & local_ch_data );
 
   channel_local_reset( );
 }


### PR DESCRIPTION
@dcompiler 's message: postwait error fixed by removing the write-map record of the posted data at the end of postwait.c:channel_post. The solution works for Ordered.  In fact the implementation can be further simplified if we only support Ordered not general dependence hints.  More thoughts needed on whether this change affects the general correctness. For now I'm done debugging in Hotel Principessa Isabella.
