### PR TITLE
bopmsg behaves same in both bop/non-bop

### DIFF
--- a/bop/bop_api.h
+++ b/bop/bop_api.h
@@ -166,7 +166,7 @@ void *_BOP_realloc(void* mem, size_t newsize, char *file, unsigned line);
 #define BOP_use( addr, size )
 #define BOP_promise( addr, size )
 
-#define bop_msg(level, string, arg) printf( string, arg )
+#define bop_msg(level, pass...) printf( pass )
 
 #define BOP_abort_spec( msg )
 #define BOP_abort_next_spec( msg )


### PR DESCRIPTION
Close #66 . Old version required exactly 3 arguments. Now requires 2+ (first is ignored, reset go to printf)
