### PR TITLE
Fix clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: c
 compiler:
   - gcc
@@ -15,15 +18,13 @@ exclude:
   - os: osx
     env: BOP_UndyFinish=0 BOP_GroupSize=4
 
-sudo: false
 addons:
   apt:
     sources:
-    - ubuntu-toolchain-r-test
+     - ubuntu-toolchain-r-test
     packages:
-    - gcc-5.3
-    - g++-5.3
-    - clang-3.5
+    - gcc
+    - clang
 #Change ssh addresses to the https equivalents on the fly
 git:
   submodules: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: c
 compiler:
   - gcc
-  - clang-3.5
+  - clang
 os:
   - linux
   #- osx
@@ -18,15 +18,18 @@ exclude:
 sudo: false
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - gcc
+    - gcc-5.3
+    - g++-5.3
     - clang-3.5
 #Change ssh addresses to the https equivalents on the fly
 git:
   submodules: false
 before_install:
   - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
-  - git submodule update --init --recursive 
+  - git submodule update --init --recursive
   - "if [[ $TRAVIS_OS_NAME = 'linux' ]]; then JOBS='-j'; fi"
   - "if [[ $TRAVIS_OS_NAME = 'osx' ]]; then brew install autoconf openssl; fi"
   - "if [[ $TRAVIS_OS_NAME = 'osx' ]]; then OPENSSL_FLAG=\"--with-openssl-dir=`brew --prefix openssl`\"; fi"


### PR DESCRIPTION
Travis-CI was using an old version of clang (3.4). some features that were used (eg CAS 128b value) requires clang 2.5
